### PR TITLE
define content type only if the body is not empty

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -847,9 +847,10 @@ class Endpoint(object):
 
         content_type_headers_list = self.headers_map['content_type']
         if content_type_headers_list:
-            header_list = self.api_client.select_header_content_type(
-                content_type_headers_list)
-            params['header']['Content-Type'] = header_list
+            if params['body'] != "":
+                header_list = self.api_client.select_header_content_type(
+                    content_type_headers_list)
+                params['header']['Content-Type'] = header_list
 
         return self.api_client.call_api(
             self.settings['endpoint_path'], self.settings['http_method'],


### PR DESCRIPTION
Content type is now only defined if the body is not empty. It used to define empty bodies and the default "application/json." This satisfies the request #8116.

I ran the desired commands on Git Bash without errors, but I am still new to this so I might have missed a step somewhere, let me know if there is anything I missed.